### PR TITLE
cairo: make directory removal more resiliant

### DIFF
--- a/meta-ivi/recipes-graphics/cairo/cairo_%.bbappend
+++ b/meta-ivi/recipes-graphics/cairo/cairo_%.bbappend
@@ -10,9 +10,10 @@ do_install_append () {
 	rm -f ${D}${bindir}/cairo-trace
 	rm -f ${D}${libdir}/cairo/libcairo-trace.so*
 
-	rmdir ${D}${bindir}
-	
-	rm -rf ${D}${libdir}/cairo
+	[ ! -d ${D}${bindir} ] ||
+		rmdir -p --ignore-fail-on-non-empty ${D}${bindir}
+	[ ! -d ${D}${libdir}/cairo ] ||
+		rmdir -p --ignore-fail-on-non-empty ${D}${libdir}/cairo
 
 	rm -f ${D}${libdir}/libcairo-script-interpreter.so*
 }


### PR DESCRIPTION
Upstream OE-core commit 9bb2268677ac8f0c97433bf1f04555abe88028a9
implements a more intelligent removal system for several install
directories which the cairo bbappend in meta-ivi then tries to modify.

Because these directories may or may not contain files, depending on the
PACKAGECONFIG state, implement the same intelligent removal system from
OE-core, after the bbappend finishes its modifications.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

## Testing
`cairo` and `cairo-native` now build in hardknott without issue.

@ni/rtos 