### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_git.bb
+++ b/meta-ivi/recipes-graphics/wayland/wayland-ivi-extension_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1f1a56bb2dadf5f2be8eb342acf4ed79"
 PR = "r0"
 
 SRCREV = "736fb654ac81230cf4f9e51a5772d3a02d7639bf"
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http;branch=master \
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http;branch=master;protocol=https \
     "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos